### PR TITLE
使用禁止関数を排除

### DIFF
--- a/srcs/socket/ServerSocket.cpp
+++ b/srcs/socket/ServerSocket.cpp
@@ -93,14 +93,20 @@ ServerSocket *ServerSocket::createServerSocket(
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (fd < 0) {
-		perror("socket");
+		errno_t err = errno;
+		LS_ERROR()
+			<< "socket() failed: " << std::strerror(err)
+			<< std::endl;
 		return NULL;
 	}
 	LS_DEBUG()
 		<< "ServerSocket created: fd=" << fd
 		<< std::endl;
 	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-		perror("bind");
+		errno_t err = errno;
+		LS_ERROR()
+			<< "bind() failed: " << std::strerror(err)
+			<< std::endl;
 		close(fd);
 		return NULL;
 	}
@@ -108,7 +114,10 @@ ServerSocket *ServerSocket::createServerSocket(
 		<< "ServerSocket bind to: " << utils::to_string(addr)
 		<< std::endl;
 	if (listen(fd, ACCEPT_BACKLOG) < 0) {
-		perror("listen");
+		errno_t err = errno;
+		LS_ERROR()
+			<< "listen() failed: " << std::strerror(err)
+			<< std::endl;
 		close(fd);
 		return NULL;
 	}

--- a/srcs/utils/url_decode.cpp
+++ b/srcs/utils/url_decode.cpp
@@ -54,7 +54,7 @@ std::string webserv::utils::url_decode(
 			percent_index = str_len;
 		}
 		size_t copy_len = percent_index - str_index;
-		memcpy(decoded_c_str + c_str_index, str.c_str() + str_index, copy_len);
+		std::memcpy(decoded_c_str + c_str_index, str.c_str() + str_index, copy_len);
 		c_str_index += copy_len;
 		if (str[percent_index] == URL_ENCODE_ESCAPE_CHAR) {
 			if (str_len <= percent_index + 2) {


### PR DESCRIPTION
- perror
- memcpy

上記の関数は使用禁止なので、
- `perror` はLoggerに移行
- `memcpy` は `std::memcpy` に移行