### PR TITLE
テスト時に時刻を固定する実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(INSTALL_GTEST "Enables installation of googletest" OFF)
 # Google Testをこのプロジェクトに組み込む
 add_subdirectory(googletest)
 
+add_definitions(-DGTEST)
+
 file(GLOB TEST_SOURCES
 	tests/*/*.cpp)
 

--- a/srcs/utils/getTimeStr.cpp
+++ b/srcs/utils/getTimeStr.cpp
@@ -1,5 +1,12 @@
 #include <utils/getTimeStr.hpp>
 
+#ifdef GTEST
+time_t __webserv_timeMockValue = 0;
+#define GET_CURRENT_TIME() (__webserv_timeMockValue)
+#else
+#define GET_CURRENT_TIME() (std::time(NULL))
+#endif
+
 namespace webserv
 {
 
@@ -8,7 +15,7 @@ namespace utils
 
 std::string getHttpTimeStr()
 {
-	return getHttpTimeStr(std::time(NULL));
+	return getHttpTimeStr(GET_CURRENT_TIME());
 }
 
 std::string getHttpTimeStr(
@@ -25,7 +32,7 @@ std::string getHttpTimeStr(
 
 std::string getIso8601ShortTimeStr()
 {
-	return getIso8601ShortTimeStr(std::time(NULL));
+	return getIso8601ShortTimeStr(GET_CURRENT_TIME());
 }
 std::string getIso8601ShortTimeStr(
 	time_t time

--- a/tests/cgi/CgiResponse.tests.cpp
+++ b/tests/cgi/CgiResponse.tests.cpp
@@ -4,6 +4,8 @@
 #include "http/HttpResponse.hpp"
 #include "utils/getTimeStr.hpp"
 
+extern time_t __webserv_timeMockValue;
+
 namespace webserv
 {
 
@@ -338,6 +340,7 @@ TEST(CgiResponseTest, ResponseModeLocalRedirect)
 
 TEST(CgiResponseTest, ResponseModeClientRedirect)
 {
+	__webserv_timeMockValue = std::time(NULL);
 	CgiResponse response(logger, utils::ErrorPageProvider());
 
 	std::string cgiResponseStr =
@@ -364,6 +367,7 @@ TEST(CgiResponseTest, ResponseModeClientRedirect)
 
 TEST(CgiResponseTest, ResponseModeClientRedirectWithBody)
 {
+	__webserv_timeMockValue = std::time(NULL);
 	CgiResponse response(logger, utils::ErrorPageProvider());
 
 	std::string cgiResponseStr =
@@ -392,6 +396,7 @@ TEST(CgiResponseTest, ResponseModeClientRedirectWithBody)
 
 TEST(CgiResponseTest, ResponseModeClientRedirectWithDocument)
 {
+	__webserv_timeMockValue = std::time(NULL);
 	CgiResponse response(logger, utils::ErrorPageProvider());
 	std::string cgiResponseStr =
 		"Status: 301 Moved Permanently\n"

--- a/tests/http/HttpResponse.test.cpp
+++ b/tests/http/HttpResponse.test.cpp
@@ -5,8 +5,11 @@
 
 #include "http/HttpFieldMap.hpp"
 
+extern time_t __webserv_timeMockValue;
+
 TEST(HttpResponse, test1)
 {
+	__webserv_timeMockValue = std::time(NULL);
 	webserv::HttpResponse response;
 	response.setVersion("HTTP/1.1");
 	response.setStatusCode("200");
@@ -18,16 +21,15 @@ TEST(HttpResponse, test1)
 	std::vector<uint8_t> bodyVec(body.begin(), body.end());
 	response.setBody(bodyVec);
 	std::vector<uint8_t> responsePacket = response.generateResponsePacket(true);
-	time_t time = std::time(NULL);
 	std::string responsePacketStr(responsePacket.begin(), responsePacket.end());
-	std::string timeStr = webserv::utils::getHttpTimeStr(time);
-	std::string expectedResponsePacketStr = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\nDate: " + timeStr + "\r\n\r\nHello, World!";
-	std::string timeStr1 = webserv::utils::getHttpTimeStr(time + 1);
-	std::string expectedResponsePacketStr1 = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\nDate: " + timeStr1 + "\r\n\r\nHello, World!";
-	// 1秒後までは許容する
-	if (expectedResponsePacketStr1 == responsePacketStr) {
-		EXPECT_EQ(responsePacketStr, expectedResponsePacketStr);
-	} else {
-		EXPECT_EQ(responsePacketStr, expectedResponsePacketStr);
-	}
+	std::string expectedResponsePacketStr =
+		"HTTP/1.1 200 OK\r\n"
+		"Content-Type: text/html\r\n"
+		"Content-Length: 13\r\n"
+		"Date: " +
+		webserv::utils::getHttpTimeStr() +
+		"\r\n"
+		"\r\n"
+		"Hello, World!";
+	EXPECT_EQ(responsePacketStr, expectedResponsePacketStr);
 }


### PR DESCRIPTION
微妙な時間に実行されることで時間の出力にズレができてしまい、失敗する可能性がある。
この可能性を排除するため、テスト時のみグローバル変数で時刻を固定して使用できるようにした。