### PR TITLE
タイムアウト実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ SRCS_SIGNAL	=\
 SRCS_SOCKET	=\
 	ClientSocket.cpp\
 	ServerSocket.cpp\
+	TimeoutChecker.cpp\
 
 SRCS_UTILS	=\
 	ErrorPageProvider.cpp\

--- a/headers/cgi/CgiHandler.hpp
+++ b/headers/cgi/CgiHandler.hpp
@@ -38,18 +38,18 @@ class CgiHandler : public Pollable
 	virtual ~CgiHandler();
 
 	virtual void setToPollFd(
-		struct pollfd &pollFd
+		struct pollfd &pollFd,
+		const struct timespec &now
 	) const;
 
 	virtual PollEventResultType onEventGot(
 		int fd,
 		short revents,
-		std::vector<Pollable *> &pollableList
+		std::vector<Pollable *> &pollableList,
+		const struct timespec &now
 	);
 
 	void setDisposeRequested();
-
-	// TODO: Redirect対応
 };
 
 }	 // namespace webserv

--- a/headers/config/ServerConfig.hpp
+++ b/headers/config/ServerConfig.hpp
@@ -17,6 +17,7 @@ class ServerConfig
 {
 	DECL_VAR_REF_GETTER_SETTER(std::vector<std::string>, ServerNameList)
 	DECL_VAR_GETTER_SETTER(uint16_t, Port)
+	DECL_VAR_GETTER_SETTER(size_t, TimeoutMs)
 	DECL_VAR_REF_GETTER_SETTER(std::size_t, RequestBodyLimit)
 	DECL_VAR_REF_GETTER_SETTER(ErrorPageMapType, ErrorPageMap)
 	DECL_VAR_REF_GETTER_SETTER(RouteListType, RouteList)
@@ -30,6 +31,7 @@ class ServerConfig
 	ServerConfig(
 		const std::vector<std::string> &serverNameList,
 		uint16_t port,
+		size_t timeoutMs,
 		std::size_t requestBodyLimit,
 		const ErrorPageMapType &errorPages,
 		const RouteListType &routeList

--- a/headers/config/ServerRunningConfig.hpp
+++ b/headers/config/ServerRunningConfig.hpp
@@ -16,6 +16,7 @@ class ServerRunningConfig
 {
  private:
 	uint16_t _port;
+	size_t _timeoutMs;
 	std::set<std::string> _serverNameList;
 	utils::ErrorPageProvider _errorPageProvider;
 	size_t _requestBodyLimit;
@@ -41,6 +42,11 @@ class ServerRunningConfig
 	inline uint16_t getPort() const
 	{
 		return this->_port;
+	}
+
+	inline size_t getTimeoutMs() const
+	{
+		return this->_timeoutMs;
 	}
 
 	inline utils::ErrorPageProvider getErrorPageProvider() const

--- a/headers/http/HttpRequest.hpp
+++ b/headers/http/HttpRequest.hpp
@@ -77,6 +77,7 @@ class HttpRequest
 	bool isChunkedRequest() const;
 	std::string getNormalizedPath() const;
 	const std::vector<std::string> &getPathSegmentList() const;
+	bool isServerRunningConfigSet() const;
 	const ServerRunningConfig &getServerRunningConfig() const;
 	void setServerRunningConfig(const ServerRunningConfig &serverRunningConfig);
 

--- a/headers/poll/Pollable.hpp
+++ b/headers/poll/Pollable.hpp
@@ -2,6 +2,7 @@
 
 #include <poll.h>
 
+#include <ctime>
 #include <stdexcept>
 #include <utils/UUID.hpp>
 #include <vector>
@@ -38,13 +39,15 @@ class Pollable
 	virtual ~Pollable();
 
 	virtual void setToPollFd(
-		struct pollfd &pollFd
+		struct pollfd &pollFd,
+		const struct timespec &now
 	) const;
 
 	virtual PollEventResultType onEventGot(
 		int fd,
 		short revents,
-		std::vector<Pollable *> &pollableList
+		std::vector<Pollable *> &pollableList,
+		const struct timespec &now
 	) = 0;
 
 	utils::UUID getUUID() const;

--- a/headers/socket/ClientSocket.hpp
+++ b/headers/socket/ClientSocket.hpp
@@ -11,6 +11,7 @@
 #include "../Logger.hpp"
 #include "../http/HttpRequest.hpp"
 #include "../http/HttpResponse.hpp"
+#include "./TimeoutChecker.hpp"
 
 namespace webserv
 {
@@ -26,8 +27,10 @@ class ClientSocket : public Pollable
 	ServiceBase *_service;
 	struct sockaddr _clientAddr;
 	bool _IsHeaderValidationCompleted;
+	TimeoutChecker _timeoutChecker;
 
 	PollEventResultType _processPollIn(
+		const struct timespec &now,
 		std::vector<Pollable *> &pollableList
 	);
 	PollEventResultType _processPollOut();
@@ -50,22 +53,22 @@ class ClientSocket : public Pollable
 	ClientSocket(
 		int fd,
 		const struct sockaddr &clientAddr,
+		const timespec &now,
 		const ServerRunningConfigListType &listenConfigList,
 		const Logger &logger
 	);
 	virtual ~ClientSocket();
 
 	virtual void setToPollFd(
-		struct pollfd &pollFd
+		struct pollfd &pollFd,
+		const struct timespec &now
 	) const;
 
 	virtual PollEventResultType onEventGot(
 		int fd,
 		short revents,
-		std::vector<Pollable *> &pollableList
-	);
-	PollEventResultType onEventGot(
-		short revents
+		std::vector<Pollable *> &pollableList,
+		const struct timespec &now
 	);
 };
 

--- a/headers/socket/ServerSocket.hpp
+++ b/headers/socket/ServerSocket.hpp
@@ -36,13 +36,15 @@ class ServerSocket : public Pollable
 	);
 
 	virtual void setToPollFd(
-		struct pollfd &pollFd
+		struct pollfd &pollFd,
+		const struct timespec &now
 	) const;
 
 	virtual PollEventResultType onEventGot(
 		int fd,
 		short revents,
-		std::vector<Pollable *> &pollableList
+		std::vector<Pollable *> &pollableList,
+		const struct timespec &now
 	);
 };
 

--- a/headers/socket/TimeoutChecker.hpp
+++ b/headers/socket/TimeoutChecker.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <Logger.hpp>
+#include <ctime>
+#include <stdexcept>
+
+#define DEFAULT_REQUEST_TIMEOUT_MS (20)
+#define SOCKET_TIMEOUT_MS (1 * 100)
+
+namespace webserv
+{
+
+class TimeoutChecker
+{
+ private:
+	TimeoutChecker(const TimeoutChecker &)
+	{
+		throw std::runtime_error("TimeoutChecker should not be copied");
+	}
+	TimeoutChecker &operator=(const TimeoutChecker &)
+	{
+		throw std::runtime_error("TimeoutChecker should not be copied");
+	}
+
+	struct timespec _start;
+	size_t _timeout_ms;
+	Logger logger;
+
+ public:
+	TimeoutChecker(
+		const timespec &start,
+		const Logger &logger,
+		size_t timeout_ms = DEFAULT_REQUEST_TIMEOUT_MS
+	);
+	virtual ~TimeoutChecker();
+
+	void setTimeoutMs(size_t timeout_ms);
+	size_t getElapsedMs(const struct timespec &now) const;
+
+	bool isTimeouted(const struct timespec &now) const;
+
+	bool isConnectionTimeouted(const struct timespec &now) const;
+};
+
+}	 // namespace webserv

--- a/headers/socket/TimeoutChecker.hpp
+++ b/headers/socket/TimeoutChecker.hpp
@@ -4,8 +4,8 @@
 #include <ctime>
 #include <stdexcept>
 
-#define DEFAULT_REQUEST_TIMEOUT_MS (20)
-#define SOCKET_TIMEOUT_MS (1 * 100)
+#define DEFAULT_REQUEST_TIMEOUT_MS (100)
+#define SOCKET_TIMEOUT_MS (1 * 1000)
 
 namespace webserv
 {

--- a/headers/utils/ErrorPageProvider.hpp
+++ b/headers/utils/ErrorPageProvider.hpp
@@ -22,6 +22,7 @@ class ErrorPageProvider
 	HttpResponse permissionDenied() const;
 	HttpResponse notFound() const;
 	HttpResponse methodNotAllowed() const;
+	HttpResponse requestTimeout() const;
 	HttpResponse requestEntityTooLarge() const;
 	HttpResponse movedPermanently() const;
 	HttpResponse found() const;
@@ -38,6 +39,7 @@ class ErrorPageProvider
 	static const int PERMISSION_DENIED = 403;
 	static const int NOT_FOUND = 404;
 	static const int METHOD_NOT_ALLOWED = 405;
+	static const int REQUEST_TIMEOUT = 408;
 	static const int REQUEST_ENTITY_TOO_LARGE = 413;
 	static const int MOVED_PERMANENTLY = 301;
 	static const int FOUND = 302;

--- a/srcs/cgi/CgiHandler.cpp
+++ b/srcs/cgi/CgiHandler.cpp
@@ -65,21 +65,24 @@ CgiHandler::~CgiHandler()
 }
 
 void CgiHandler::setToPollFd(
-	struct pollfd &pollFd
+	struct pollfd &pollFd,
+	const struct timespec &now
 ) const
 {
-	Pollable::setToPollFd(pollFd);
+	Pollable::setToPollFd(pollFd, now);
 	pollFd.events = POLLIN;
 }
 
 PollEventResultType CgiHandler::onEventGot(
 	int fd,
 	short revents,
-	std::vector<Pollable *> &pollableList
+	std::vector<Pollable *> &pollableList,
+	const struct timespec &now
 )
 {
 	(void)fd;
 	(void)pollableList;
+	(void)now;
 	if (this->_cgiServiceCgiHandlerField == NULL || this->_cgiServiceHttpResponseField == NULL) {
 		C_WARN("CgiHandler is not set to CGI service");
 		return PollEventResult::DISPOSE_REQUEST;

--- a/srcs/config/ServerConfig.cpp
+++ b/srcs/config/ServerConfig.cpp
@@ -8,6 +8,7 @@ namespace webserv
 ServerConfig::ServerConfig(
 ) : _ServerNameList(),
 		_Port(0),
+		_TimeoutMs(100),
 		_RequestBodyLimit(0),
 		_ErrorPageMap(),
 		_RouteList()
@@ -18,6 +19,7 @@ webserv::ServerConfig::ServerConfig(
 	const ServerConfig &from
 ) : _ServerNameList(from._ServerNameList),
 		_Port(from._Port),
+		_TimeoutMs(from._TimeoutMs),
 		_RequestBodyLimit(from._RequestBodyLimit),
 		_ErrorPageMap(from._ErrorPageMap),
 		_RouteList(from._RouteList)
@@ -37,6 +39,7 @@ ServerConfig &webserv::ServerConfig::operator=(
 
 	this->_ServerNameList = from._ServerNameList;
 	this->_Port = from._Port;
+	this->_TimeoutMs = from._TimeoutMs;
 	this->_RequestBodyLimit = from._RequestBodyLimit;
 	this->_ErrorPageMap = from._ErrorPageMap;
 	this->_RouteList = from._RouteList;
@@ -47,11 +50,13 @@ ServerConfig &webserv::ServerConfig::operator=(
 ServerConfig::ServerConfig(
 	const std::vector<std::string> &serverNameList,
 	uint16_t port,
+	size_t timeoutMs,
 	std::size_t requestBodyLimit,
 	const ErrorPageMapType &errorPageMap,
 	const RouteListType &routeList
 ) : _ServerNameList(serverNameList),
 		_Port(port),
+		_TimeoutMs(timeoutMs),
 		_RequestBodyLimit(requestBodyLimit),
 		_ErrorPageMap(errorPageMap),
 		_RouteList(routeList)

--- a/srcs/config/ServerRunningConfig.cpp
+++ b/srcs/config/ServerRunningConfig.cpp
@@ -65,6 +65,7 @@ ServerRunningConfig::ServerRunningConfig(
 	utils::ErrorPageProvider &errorPageProvider,
 	Logger &logger
 ) : _port(serverConfig.getPort()),
+		_timeoutMs(serverConfig.getTimeoutMs()),
 		_serverNameList(_ServerNameVecToSet(serverConfig.getServerNameList())),
 		_errorPageProvider(errorPageProvider),
 		_requestBodyLimit(serverConfig.getRequestBodyLimit()),
@@ -94,6 +95,7 @@ ServerRunningConfig::ServerRunningConfig(
 ServerRunningConfig::ServerRunningConfig(
 	const ServerRunningConfig &from
 ) : _port(from._port),
+		_timeoutMs(from._timeoutMs),
 		_serverNameList(from._serverNameList),
 		_errorPageProvider(from._errorPageProvider),
 		_requestBodyLimit(from._requestBodyLimit),

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -306,6 +306,11 @@ const std::vector<std::string> &HttpRequest::getPathSegmentList() const
 	return this->_PathSegmentList;
 }
 
+bool HttpRequest::isServerRunningConfigSet() const
+{
+	return this->serverRunningConfig != NULL;
+}
+
 const ServerRunningConfig &HttpRequest::getServerRunningConfig() const
 {
 	return *this->serverRunningConfig;

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -115,6 +115,7 @@ static webserv::ServerRunningConfigListType createDefaultServerConfigList(
 	webserv::ServerConfig serverConfig(
 		hostNameList,
 		port,
+		20,
 		// 128MB
 		128 * 1024 * 1024,
 		errorPageFileMap,

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -115,7 +115,7 @@ static webserv::ServerRunningConfigListType createDefaultServerConfigList(
 	webserv::ServerConfig serverConfig(
 		hostNameList,
 		port,
-		20,
+		100,
 		// 128MB
 		128 * 1024 * 1024,
 		errorPageFileMap,

--- a/srcs/poll/Pollable.cpp
+++ b/srcs/poll/Pollable.cpp
@@ -31,9 +31,11 @@ int Pollable::getFD() const
 }
 
 void Pollable::setToPollFd(
-	struct pollfd &pollFd
+	struct pollfd &pollFd,
+	const struct timespec &now
 ) const
 {
+	(void)now;
 	pollFd.fd = this->_fd;
 	pollFd.events = POLLIN | POLLOUT;
 	pollFd.revents = 0;

--- a/srcs/socket/ClientSocket.cpp
+++ b/srcs/socket/ClientSocket.cpp
@@ -28,11 +28,36 @@ static const ServerRunningConfig &pickServerConfig(
 PollEventResultType ClientSocket::onEventGot(
 	int fd,
 	short revents,
-	std::vector<Pollable *> &pollableList
+	std::vector<Pollable *> &pollableList,
+	const struct timespec &now
 )
 {
-	(void)pollableList;
-	// TODO: タイムアウト監視 (呼び出し元でのreventチェックを取り除いて実装)
+	if (this->_timeoutChecker.isConnectionTimeouted(now)) {
+		CS_WARN()
+			<< "Connection Timeout"
+			<< std::endl;
+		return PollEventResult::DISPOSE_REQUEST;
+	}
+
+	if (!this->_IsResponseSet && this->_timeoutChecker.isTimeouted(now)) {
+		if (this->httpRequest.isServerRunningConfigSet()) {
+			C_WARN("Gateway Timeout");
+			if (this->httpRequest.isParseCompleted()) {
+				this->_setResponse(this->httpRequest.getServerRunningConfig().getErrorPageProvider().gatewayTimeout());
+			} else {
+				this->_setResponse(this->httpRequest.getServerRunningConfig().getErrorPageProvider().requestTimeout());
+			}
+		} else {
+			C_WARN("Request Timeout");
+			this->_setResponse(this->_listenConfigList[0].getErrorPageProvider().requestTimeout());
+		}
+
+		if (this->_service != NULL) {
+			this->_service->setIsDisposingFromChildProcess(this->isDisposingFromChildProcess());
+			delete this->_service;
+			this->_service = NULL;
+		}
+	}
 
 	if (this->_service != NULL) {
 		if (this->isFdSame(fd)) {
@@ -55,7 +80,7 @@ PollEventResultType ClientSocket::onEventGot(
 		CS_DEBUG()
 			<< "POLLIN event"
 			<< std::endl;
-		return this->_processPollIn(pollableList);
+		return this->_processPollIn(now, pollableList);
 	} else if (IS_POLLOUT(revents)) {
 		CS_DEBUG()
 			<< "POLLOUT event"
@@ -67,6 +92,7 @@ PollEventResultType ClientSocket::onEventGot(
 }
 
 PollEventResultType ClientSocket::_processPollIn(
+	const struct timespec &now,
 	std::vector<Pollable *> &pollableList
 )
 {
@@ -135,6 +161,15 @@ PollEventResultType ClientSocket::_processPollIn(
 		}
 
 		httpRequest.setServerRunningConfig(serverRunningConfig);
+
+		this->_timeoutChecker.setTimeoutMs(serverRunningConfig.getTimeoutMs());
+		if (this->_timeoutChecker.isTimeouted(now)) {
+			CS_WARN()
+				<< "Request timeout"
+				<< std::endl;
+			this->_setResponse(serverRunningConfig.getErrorPageProvider().requestTimeout());
+			return PollEventResult::OK;
+		}
 	}
 
 	if (!this->httpRequest.isParseCompleted()) {
@@ -342,12 +377,15 @@ void ClientSocket::_setResponse(
 }
 
 void ClientSocket::setToPollFd(
-	struct pollfd &pollFd
+	struct pollfd &pollFd,
+	const struct timespec &now
 ) const
 {
-	Pollable::setToPollFd(pollFd);
-	if (this->_service == NULL) {
-		pollFd.events = this->_IsResponseSet ? POLLOUT : POLLIN;
+	Pollable::setToPollFd(pollFd, now);
+	bool isResponseAvailable = this->_IsResponseSet || this->_timeoutChecker.isTimeouted(now);
+
+	if (isResponseAvailable || this->_service == NULL) {
+		pollFd.events = isResponseAvailable ? POLLOUT : POLLIN;
 	} else {
 		this->_service->setToPollFd(pollFd);
 	}
@@ -380,6 +418,7 @@ ClientSocket::~ClientSocket()
 ClientSocket::ClientSocket(
 	int fd,
 	const struct sockaddr &clientAddr,
+	const timespec &now,
 	const ServerRunningConfigListType &listenConfigList,
 	const Logger &logger
 ) : Pollable(fd),
@@ -389,7 +428,8 @@ ClientSocket::ClientSocket(
 		_IsResponseSet(false),
 		_service(NULL),
 		_clientAddr(clientAddr),
-		_IsHeaderValidationCompleted(false)
+		_IsHeaderValidationCompleted(false),
+		_timeoutChecker(now, logger)
 {
 	CS_DEBUG()
 		<< "ClientSocket(fd:" << utils::to_string(fd) << ")"

--- a/srcs/socket/ServerSocket.cpp
+++ b/srcs/socket/ServerSocket.cpp
@@ -19,7 +19,8 @@ namespace webserv
 PollEventResultType ServerSocket::onEventGot(
 	int fd,
 	short revents,
-	std::vector<Pollable *> &pollableList
+	std::vector<Pollable *> &pollableList,
+	const struct timespec &now
 )
 {
 	(void)fd;
@@ -62,6 +63,7 @@ PollEventResultType ServerSocket::onEventGot(
 	Pollable *clientSocket = new ClientSocket(
 		clientFd,
 		clientAddr,
+		now,
 		this->_listenConfigList,
 		this->logger
 	);
@@ -74,10 +76,11 @@ PollEventResultType ServerSocket::onEventGot(
 }
 
 void ServerSocket::setToPollFd(
-	struct pollfd &pollFd
+	struct pollfd &pollFd,
+	const struct timespec &now
 ) const
 {
-	Pollable::setToPollFd(pollFd);
+	Pollable::setToPollFd(pollFd, now);
 	pollFd.events = POLLIN;
 }
 

--- a/srcs/socket/TimeoutChecker.cpp
+++ b/srcs/socket/TimeoutChecker.cpp
@@ -1,0 +1,60 @@
+#include <algorithm>
+#include <iostream>
+#include <socket/TimeoutChecker.hpp>
+
+#define SEC_TO_MS(sec) ((sec) * 1000)
+#define NSEC_TO_MS(nsec) ((nsec) / (1000 * 1000))
+
+namespace webserv
+{
+
+TimeoutChecker::TimeoutChecker(
+	const timespec &start,
+	const Logger &logger,
+	size_t timeout_ms
+) : _start(start),
+		logger(logger)
+{
+	this->setTimeoutMs(timeout_ms);
+	CS_INFO()
+		<< "TimeoutMs: " << std::dec << this->_timeout_ms
+		<< std::endl;
+}
+
+TimeoutChecker::~TimeoutChecker()
+{
+}
+
+void TimeoutChecker::setTimeoutMs(
+	size_t timeout_ms
+)
+{
+	this->_timeout_ms = std::min(timeout_ms, (size_t)SOCKET_TIMEOUT_MS);
+	CS_INFO()
+		<< "TimeoutMs: " << std::dec << this->_timeout_ms
+		<< "(requested: " << std::dec << timeout_ms << ")"
+		<< std::endl;
+}
+
+size_t TimeoutChecker::getElapsedMs(
+	const struct timespec &now
+) const
+{
+	return (size_t)(SEC_TO_MS(now.tv_sec - this->_start.tv_sec) + NSEC_TO_MS(now.tv_nsec - this->_start.tv_nsec));
+}
+
+bool TimeoutChecker::isTimeouted(
+	const timespec &now
+) const
+{
+	return this->_timeout_ms <= this->getElapsedMs(now);
+}
+
+bool TimeoutChecker::isConnectionTimeouted(
+	const timespec &now
+) const
+{
+	return SOCKET_TIMEOUT_MS <= this->getElapsedMs(now);
+}
+
+}	 // namespace webserv

--- a/srcs/utils/ErrorPageProvider.cpp
+++ b/srcs/utils/ErrorPageProvider.cpp
@@ -21,6 +21,7 @@ const int ErrorPageProvider::BAD_REQUEST;
 const int ErrorPageProvider::PERMISSION_DENIED;
 const int ErrorPageProvider::NOT_FOUND;
 const int ErrorPageProvider::METHOD_NOT_ALLOWED;
+const int ErrorPageProvider::REQUEST_TIMEOUT;
 const int ErrorPageProvider::REQUEST_ENTITY_TOO_LARGE;
 const int ErrorPageProvider::MOVED_PERMANENTLY;
 const int ErrorPageProvider::FOUND;
@@ -72,6 +73,12 @@ static const HttpResponse defaultMethodNotAllowed = createResponse(
 	ErrorPageProvider::METHOD_NOT_ALLOWED,
 	"Method Not Allowed",
 	"405 Method Not Allowed\n"
+);
+
+static const HttpResponse defaultRequestTimeout = createResponse(
+	ErrorPageProvider::REQUEST_TIMEOUT,
+	"Request Timeout",
+	"408 Request Timeout\n"
 );
 
 static const HttpResponse defaultRequestEntityTooLarge = createResponse(
@@ -128,6 +135,8 @@ ErrorPageProvider::ErrorPageProvider()
 	this->_errorPages[ErrorPageProvider::BAD_REQUEST] = defaultBadRequest;
 	this->_errorPages[ErrorPageProvider::PERMISSION_DENIED] = defaultPermissionDenied;
 	this->_errorPages[ErrorPageProvider::NOT_FOUND] = defaultNotFound;
+	this->_errorPages[ErrorPageProvider::METHOD_NOT_ALLOWED] = defaultMethodNotAllowed;
+	this->_errorPages[ErrorPageProvider::REQUEST_TIMEOUT] = defaultRequestTimeout;
 	this->_errorPages[ErrorPageProvider::REQUEST_ENTITY_TOO_LARGE] = defaultRequestEntityTooLarge;
 	this->_errorPages[ErrorPageProvider::MOVED_PERMANENTLY] = defaultMovedPermanently;
 	this->_errorPages[ErrorPageProvider::FOUND] = defaultFound;
@@ -232,6 +241,11 @@ HttpResponse ErrorPageProvider::notFound() const
 HttpResponse ErrorPageProvider::methodNotAllowed() const
 {
 	return this->_errorPages.at(ErrorPageProvider::METHOD_NOT_ALLOWED);
+}
+
+HttpResponse ErrorPageProvider::requestTimeout() const
+{
+	return this->_errorPages.at(ErrorPageProvider::REQUEST_TIMEOUT);
 }
 
 HttpResponse ErrorPageProvider::requestEntityTooLarge() const


### PR DESCRIPTION
指定時間でタイムアウトするようにしました。

タイムアウトには2種類あります。

1. リクエストのタイムアウト
2. コネクションのタイムアウト

リクエストのタイムアウトが発生した場合、タイムアウト系のエラーを返します。既にレスポンスを生成済みの場合はそれをそのまま返そうとします。
この設定は、`ServerConfig` に新しく追加した `TimeoutMs` プロパティにて、ms単位で設定できます。unsignedなので0以上です。
`ServerConfig` なので、リクエストヘッダを読み切るまでは固定値のタイムアウト設定が適用されます (デフォルト: 100ms)。 リクエストヘッダを読み切り次第、タイムアウト設定が各サーバー固有のものになります。
将来的にはServerRunningConfigの取得自体を `Host` フィールド読み込み完了時にしたいですが、面倒なのでとりあえずは現状のままです。

コネクションのタイムアウトが発生した場合、コネクションを強制的に閉じます。レスポンスを返している途中であっても強制的に閉じます。
このタイムアウト時間は完全に固定値です。サーバー動作の根幹に関わるため、またバリデーションが面倒なので、設定ファイルで変更することはできません。

---

タイムアウトを実装したため、Local Redirectのリダイレクト数制限は実装しません。タイムアウトするまで処理され続けます。