### PR TITLE
PostFileService ディレクトリのチェック漏れを修正

### DIFF
--- a/headers/service/RequestedFileInfo.hpp
+++ b/headers/service/RequestedFileInfo.hpp
@@ -30,6 +30,7 @@ class RequestedFileInfo
 	DECL_VAR_GETTER(bool, IsNotFound);
 	DECL_VAR_GETTER(bool, IsCgi);
 	DECL_VAR_GETTER(bool, IsAutoIndexAllowed);
+	DECL_VAR_GETTER(bool, IsAutoIndexFile);
 	DECL_VAR_REF_GETTER(CgiConfig, CgiConfig);
 	DECL_VAR_REF_GETTER(struct stat, StatBuf);
 	DECL_VAR_REF_GETTER(std::string, FileExtensionWithoutDot);

--- a/srcs/service/PostFileService.cpp
+++ b/srcs/service/PostFileService.cpp
@@ -18,6 +18,15 @@ namespace webserv
 
 #define BUFFER_SIZE 4096
 
+static std::string getDirName(const std::string &path)
+{
+	size_t pos = path.rfind('/');
+	if (pos == std::string::npos) {
+		return "";
+	}
+	return path.substr(0, pos + 1);
+}
+
 PostFileService::PostFileService(
 	const HttpRequest &request,
 	const RequestedFileInfo &requestedFileInfo,
@@ -29,21 +38,67 @@ PostFileService::PostFileService(
 {
 	std::string filePath(requestedFileInfo.getTargetFilePath());
 
-	// ファイルが存在しない場合も実行されるので注意
-	if (requestedFileInfo.getIsNotFound()) {
-		// TODO: 親ディレクトリが存在するか確認し、存在しなかったらNotFoundを返す
-	}
-
-	if (access(filePath.c_str(), W_OK) != 0) {
-		this->_response = this->_errorPageProvider.permissionDenied();
-		LS_INFO() << "Permission denied: " << filePath << std::endl;
+	// ディレクトリにファイルを作成することはできない
+	// AutoIndexファイルへの書き込みは許可しない
+	// PathInfoがあるということは、目的でないファイルである可能性があるため、許可しない
+	if (requestedFileInfo.getIsDirectory() || requestedFileInfo.getIsAutoIndexFile() || !requestedFileInfo.getCgiPathInfo().empty()) {
+		this->_response = this->_errorPageProvider.methodNotAllowed();
+		LS_INFO() << "Method not allowed: " << filePath << std::endl;
 		return;
 	}
 
-	this->_fd = open(filePath.c_str(), O_WRONLY | O_TRUNC);
+	// ファイルが存在しなかった場合は、親ディレクトリが存在する場合にのみファイルの新規作成を行う
+	if (requestedFileInfo.getIsNotFound()) {
+		std::string dirPath = getDirName(filePath);
+		struct stat statBuf;
+		if (stat(dirPath.c_str(), &statBuf) != 0) {
+			errno_t err = errno;
+			this->_response = this->_errorPageProvider.notFound();
+			LS_INFO()
+				<< "Parent Directory Not Found: " << requestedFileInfo.getDocumentRoot()
+				<< " (err: " << std::strerror(err) << ")"
+				<< std::endl;
+			return;
+		}
+		LS_LOG()
+			<< "Directory info: "
+			<< "Path: " << dirPath << ", "
+			<< "User ID: " << statBuf.st_uid << ", "
+			<< "Group ID: " << statBuf.st_gid << ", "
+			<< "File size: " << statBuf.st_size << ", "
+			<< "Block size: " << statBuf.st_blksize << ", "
+			<< "Block count: " << statBuf.st_blocks << ", "
+			<< "Permissions: " << utils::modeToString(statBuf.st_mode) << ", "
+			<< "Last modified: " << utils::getHttpTimeStr(statBuf.st_mtime)
+			<< std::endl;
+		if (access(dirPath.c_str(), W_OK) != 0) {
+			this->_response = this->_errorPageProvider.permissionDenied();
+			LS_INFO() << "Permission denied: " << filePath << std::endl;
+			return;
+		}
+
+		this->_fd = open(
+			filePath.c_str(),
+			O_WRONLY | O_CREAT | O_TRUNC,
+			S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+		);
+	} else {
+		if (access(filePath.c_str(), W_OK) != 0) {
+			this->_response = this->_errorPageProvider.permissionDenied();
+			LS_INFO() << "Permission denied: " << filePath << std::endl;
+			return;
+		}
+
+		this->_fd = open(filePath.c_str(), O_WRONLY | O_TRUNC);
+	}
+
 	if (this->_fd < 0) {
 		errno_t err = errno;
-		this->_response = this->_errorPageProvider.internalServerError();
+		if (err == EACCES) {
+			this->_response = this->_errorPageProvider.permissionDenied();
+		} else {
+			this->_response = this->_errorPageProvider.internalServerError();
+		}
 		LS_ERROR()
 			<< "Failed to open file: " << filePath
 			<< " (err: " << std::strerror(err) << ")"
@@ -89,6 +144,10 @@ ServiceEventResultType PostFileService::onEventGot(
 
 	size_t dataSize = this->_request.getBody().size() - this->_writtenSize;
 	size_t writeSize = std::min(dataSize, static_cast<size_t>(INT_MAX));
+	CS_LOG()
+		<< "Writing " << writeSize << " / " << this->_request.getBody().size() << " bytes"
+		<< " (already written: " << this->_writtenSize << ")"
+		<< std::endl;
 	ssize_t writtenLength = write(
 		this->_fd,
 		this->_request.getBody().data() + this->_writtenSize,
@@ -106,7 +165,7 @@ ServiceEventResultType PostFileService::onEventGot(
 
 	this->_writtenSize += writtenLength;
 	if (this->_request.getBody().size() == this->_writtenSize) {
-		LS_DEBUG() << "Write " << writtenLength << " bytes" << std::endl;
+		LS_DEBUG() << "Write " << writtenLength << " bytes Completed" << std::endl;
 		return ServiceEventResult::COMPLETE;
 	}
 

--- a/srcs/service/PostFileService.cpp
+++ b/srcs/service/PostFileService.cpp
@@ -24,7 +24,8 @@ PostFileService::PostFileService(
 	const webserv::utils::ErrorPageProvider &errorPageProvider,
 	const Logger &logger
 ) : ServiceBase(request, errorPageProvider, logger),
-		_fd(-1)
+		_fd(-1),
+		_writtenSize(0)
 {
 	std::string filePath(requestedFileInfo.getTargetFilePath());
 

--- a/srcs/service/RequestedFileInfo.cpp
+++ b/srcs/service/RequestedFileInfo.cpp
@@ -26,6 +26,7 @@ RequestedFileInfo::RequestedFileInfo(
 		_IsNotFound(false),
 		_IsCgi(false),
 		_IsAutoIndexAllowed(routeConfig.getIsDocumentListingEnabled()),
+		_IsAutoIndexFile(false),
 		_CgiConfig(),
 		_StatBuf(),
 		_FileExtensionWithoutDot()
@@ -219,6 +220,7 @@ void RequestedFileInfo::_findIndexFile(
 		this->_TargetFilePathWithoutDocumentRoot = joinPath(this->_TargetFilePathWithoutDocumentRoot, *it);
 		this->_CgiScriptName = joinPath(this->_CgiScriptName, *it);
 		this->_IsDirectory = false;
+		this->_IsAutoIndexFile = true;
 		this->_StatBuf = statBuf;
 		LS_INFO()
 			<< "Index file found: " << indexFilePath

--- a/srcs/service/pickService.cpp
+++ b/srcs/service/pickService.cpp
@@ -66,7 +66,6 @@ static ServiceBase *pickService(
 		);
 	}
 
-	// TODO: RouteによるServiceの選択 (特にCGI対応)
 	if (request.getMethod() == "GET" || request.getMethod() == "HEAD") {
 		L_INFO("GetFileService selected");
 		return new GetFileService(

--- a/srcs/socket/ClientSocket.cpp
+++ b/srcs/socket/ClientSocket.cpp
@@ -145,6 +145,7 @@ PollEventResultType ClientSocket::_processPollIn(
 
 	CS_DEBUG()
 		<< "Request parse completed"
+		<< "Body size: " << this->httpRequest.getContentLength()
 		<< std::endl;
 	this->_service = pickService(
 		this->_clientAddr,

--- a/tests/service/RequestedFileInfo.tests.cpp
+++ b/tests/service/RequestedFileInfo.tests.cpp
@@ -105,6 +105,7 @@ TEST_F(RequestedFileInfoTests, testDocumentRoot)
 	EXPECT_TRUE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -126,6 +127,7 @@ TEST_F(RequestedFileInfoTests, testDocumentRootAutoIndex)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -146,6 +148,7 @@ TEST_F(RequestedFileInfoTests, detectIndexHtml)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("html", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -166,6 +169,7 @@ TEST_F(RequestedFileInfoTests, detectIndexHtml_AutoIndex)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("html", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -186,6 +190,7 @@ TEST_F(RequestedFileInfoTests, detectIndexPhp_NoPhpRoute)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("php", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -206,6 +211,7 @@ TEST_F(RequestedFileInfoTests, detectIndexPhp_PhpRoute)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_TRUE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_TRUE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("php", requestedFileInfo.getFileExtensionWithoutDot());
 	EXPECT_EQ(this->getRouteConfigCgi().getCgiConfigList()[0].getCgiExecutableFullPath(), requestedFileInfo.getCgiConfig().getCgiExecutableFullPath());
@@ -226,6 +232,7 @@ TEST_F(RequestedFileInfoTests, indexPhp_NoPhpRoute_PathInfo)
 	EXPECT_TRUE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("php", requestedFileInfo.getFileExtensionWithoutDot());
 }
@@ -246,6 +253,7 @@ TEST_F(RequestedFileInfoTests, indexPhp_PhpRoute_PathInfo)
 	EXPECT_FALSE(requestedFileInfo.getIsNotFound());
 	EXPECT_TRUE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexFile());
 
 	EXPECT_EQ("php", requestedFileInfo.getFileExtensionWithoutDot());
 	EXPECT_EQ(this->getRouteConfigCgi().getCgiConfigList()[0].getCgiExecutableFullPath(), requestedFileInfo.getCgiConfig().getCgiExecutableFullPath());
@@ -267,6 +275,7 @@ TEST_F(RequestedFileInfoTests, directoryRequestButWasFile)
 	EXPECT_TRUE(requestedFileInfo.getIsNotFound());
 	EXPECT_FALSE(requestedFileInfo.getIsCgi());
 	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexAllowed());
+	EXPECT_FALSE(requestedFileInfo.getIsAutoIndexFile());
 }
 
 };	// namespace webserv


### PR DESCRIPTION
親ディレクトリが存在するかをチェックし忘れていたので、チェックするようにしました。

ついでに、writtenSizeの初期化も忘れていてバグっていたので、きちんと初期化するようにしました。